### PR TITLE
Deleting onlyBikeOwner and adding index to Donation

### DIFF
--- a/contracts/challenge_day_one/05/BikeShare.sol
+++ b/contracts/challenge_day_one/05/BikeShare.sol
@@ -49,10 +49,6 @@ contract BikeShare {
     /**************************************
     * Modifiers
     **************************************/
-    modifier onlyBikeOwner(uint256 _bikeNumber) {
-        require(bikes[_bikeNumber].owner == msg.sender);
-        _;
-    }
     modifier canRent(uint256 _bikeNumber) {
         require(bikeRented[msg.sender] == 0 && !bikes[_bikeNumber].isRented);
         _;

--- a/contracts/challenge_day_one/05/README.md
+++ b/contracts/challenge_day_one/05/README.md
@@ -10,9 +10,8 @@ Implement 3 functions:
 - rideBike: takes in the amount of kilometers the user is riding the bike, reduces the amount of credits the user has accordingly
 - returnBike: let's the user return the bike
 
-Create 4 modifiers with these functionalities:
+Create 3 modifiers with these functionalities:
 
-- A modifier called onlyBikeOwner, that takes in a bikeNumber as argument and reverts if the bike owner of the specific bike is not the sender of the message
 - A modifier called canRent, that takes in a bikeNumber as argument ensures that the bike is not rented, and that the owner is currently not renting another bike
 - A modifier called hasRental, that takes in no arguments and ensures that the message sender owns the rental
 - A modifier called hasEnoughCredits, that takes in the amount of kilometers the owner wants to bike, and ensure that he has enough credits when calculating the kilometers times the cost per kilometers

--- a/contracts/challenge_day_one/06/BikeShare.sol
+++ b/contracts/challenge_day_one/06/BikeShare.sol
@@ -52,10 +52,6 @@ contract BikeShare is Ownable {
     /**************************************
     * Modifiers
     **************************************/
-    modifier onlyBikeOwner(uint256 _bikeNumber) {
-        require(bikes[_bikeNumber].owner == msg.sender);
-        _;
-    }
     modifier canRent(uint256 _bikeNumber) {
         require(bikeRented[msg.sender] == 0 && !bikes[_bikeNumber].isRented);
         _;

--- a/contracts/challenge_day_one/07/BikeShare.sol
+++ b/contracts/challenge_day_one/07/BikeShare.sol
@@ -51,7 +51,7 @@ contract BikeShare is Ownable {
     /**************************************
     * Events
     **************************************/
-    event Donation(address _from, uint256 _amount);
+    event Donation(address indexed _from, uint256 _amount);
     event CreditsPurchased(address indexed _to, uint256 _ethAmount, uint256 _creditAmount);
     event BikeRented(address _renter, uint256 indexed _bikeNumber);
     event BikeRidden(address _renter, uint256 indexed _bikeNumber, uint256 _kms);

--- a/contracts/challenge_day_one/07/BikeShare.sol
+++ b/contracts/challenge_day_one/07/BikeShare.sol
@@ -60,10 +60,6 @@ contract BikeShare is Ownable {
     /**************************************
     * Modifiers
     **************************************/
-    modifier onlyBikeOwner(uint256 _bikeNumber) {
-        require(bikes[_bikeNumber].owner == msg.sender);
-        _;
-    }
     modifier canRent(uint256 _bikeNumber) {
         require(bikeRented[msg.sender] == 0 && !bikes[_bikeNumber].isRented);
         _;

--- a/contracts/challenge_day_one/08/BikeShare.sol
+++ b/contracts/challenge_day_one/08/BikeShare.sol
@@ -51,7 +51,7 @@ contract BikeShare is Ownable {
     /**************************************
     * Events
     **************************************/
-    event Donation(address _from, uint256 _amount);
+    event Donation(address indexed _from, uint256 _amount);
     event CreditsPurchased(address indexed _to, uint256 _ethAmount, uint256 _creditAmount);
     event BikeRented(address _renter, uint256 indexed _bikeNumber);
     event BikeRidden(address _renter, uint256 indexed _bikeNumber, uint256 _kms);

--- a/contracts/challenge_day_one/08/BikeShare.sol
+++ b/contracts/challenge_day_one/08/BikeShare.sol
@@ -60,10 +60,6 @@ contract BikeShare is Ownable {
     /**************************************
     * Modifiers
     **************************************/
-    modifier onlyBikeOwner(uint256 _bikeNumber) {
-        require(bikes[_bikeNumber].owner == msg.sender);
-        _;
-    }
     modifier canRent(uint256 _bikeNumber) {
         require(bikeRented[msg.sender] == 0 && !bikes[_bikeNumber].isRented);
         _;

--- a/contracts/challenge_day_one/final/contracts/BikeShare.sol
+++ b/contracts/challenge_day_one/final/contracts/BikeShare.sol
@@ -53,7 +53,7 @@ contract BikeShare is Ownable {
     /**************************************
     * Events
     **************************************/
-    event Donation(address _from, uint256 _amount);
+    event Donation(address indexed _from, uint256 _amount);
     event CreditsPurchased(address indexed _to, uint256 _ethAmount, uint256 _creditAmount);
     event BikeRented(address _renter, uint256 indexed _bikeNumber);
     event BikeRidden(address _renter, uint256 indexed _bikeNumber, uint256 _kms);

--- a/contracts/challenge_day_one/final/contracts/BikeShare.sol
+++ b/contracts/challenge_day_one/final/contracts/BikeShare.sol
@@ -62,10 +62,6 @@ contract BikeShare is Ownable {
     /**************************************
     * Modifiers
     **************************************/
-    modifier onlyBikeOwner(uint256 _bikeNumber) {
-        require(bikes[_bikeNumber].owner == msg.sender);
-        _;
-    }
     modifier canRent(uint256 _bikeNumber) {
         require(bikeRented[msg.sender] == 0 && !bikes[_bikeNumber].isRented);
         _;


### PR DESCRIPTION
One of hasRental and onlyBikeOwner is redundant, and it's easier to delete onlyBikeOwner since it doesn't get used. Requiring only the person renting the bike to make changed to their own bike would be the most secure, but that security is already baked into rentBike and rideBike anyway since it's based on msg.sender.
Using onlyBikeOwner would require having 'bikes[_bikeNumber].owner = msg.sender' every time someone rents a bike, and you probably don't want to name the rentee as the owner.
Added index to Donation event.